### PR TITLE
CMake: more cleanup, now uses clapack from our own fork on github: ht…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,78 +22,70 @@ if (UNIX)
 endif (UNIX)
 
 # Auto detect if Fortran compiler has been installed
-if (NOT CISSTNETLIB_LANGUAGE)
+if (NOT cisstNetlib_LANGUAGE)
   enable_language (Fortran OPTIONAL)
   if (CMAKE_Fortran_COMPILER_WORKS)
-    set (CISSTNETLIB_LANGUAGE "Fortran" CACHE STRING "C or Fortran \(exact match\)" FORCE)
+    set (cisstNetlib_LANGUAGE "Fortran" CACHE STRING "C or Fortran \(exact match\)" FORCE)
   else ()
-    set (CISSTNETLIB_LANGUAGE "C" CACHE STRING "C or Fortran \(exact match\)" FORCE)
+    set (cisstNetlib_LANGUAGE "C" CACHE STRING "C or Fortran \(exact match\)" FORCE)
   endif ()
 endif ()
 
 
 # --- determine language, C or Fortran
 set (_languageIsValid OFF)
-if ("${CISSTNETLIB_LANGUAGE}" STREQUAL "C")
+if ("${cisstNetlib_LANGUAGE}" STREQUAL "C")
   set (_languageIsValid ON)
-else ("${CISSTNETLIB_LANGUAGE}" STREQUAL "C")
-  if ("${CISSTNETLIB_LANGUAGE}" STREQUAL "Fortran")
+else ("${cisstNetlib_LANGUAGE}" STREQUAL "C")
+  if ("${cisstNetlib_LANGUAGE}" STREQUAL "Fortran")
     set (_languageIsValid ON)
-  endif ("${CISSTNETLIB_LANGUAGE}" STREQUAL "Fortran")
-endif ("${CISSTNETLIB_LANGUAGE}" STREQUAL "C")
+  endif ("${cisstNetlib_LANGUAGE}" STREQUAL "Fortran")
+endif ("${cisstNetlib_LANGUAGE}" STREQUAL "C")
 
 if (NOT ${_languageIsValid})
-  message (FATAL_ERROR "CISSTNETLIB_LANGUAGE must be either \"C\" or \"Fortran\"")
+  message (FATAL_ERROR "cisstNetlib_LANGUAGE must be either \"C\" or \"Fortran\"")
 endif (NOT ${_languageIsValid})
 
 # --- cisstNetlib configuration
-if ("${CISSTNETLIB_LANGUAGE}" STREQUAL "Fortran")
-  project (cisstNetlib LANGUAGES Fortran C VERSION 3.1.0)
+if ("${cisstNetlib_LANGUAGE}" STREQUAL "Fortran")
+  set (cisstNetlib_LANGUAGES "Fortran;C")
 else ()
-  project (cisstNetlib LANGUAGES C VERSION 3.1.0)
+  set (cisstNetlib_LANGUAGES "C")
 endif ()
+
+project (cisstNetlib LANGUAGES ${cisstNetlib_LANGUAGES} VERSION 3.1.0)
 
 # --- determine architecture
 if (APPLE)
-  set (CISSTNETLIB_ARCHITECTURE "universal")
+  set (cisstNetlib_ARCHITECTURE "universal")
 else (APPLE)
   if (WIN32)
     if (CMAKE_CL_64)
-      set (CISSTNETLIB_ARCHITECTURE "x86_64")
+      set (cisstNetlib_ARCHITECTURE "x86_64")
     else (CMAKE_CL_64)
-      set (CISSTNETLIB_ARCHITECTURE "i686")
+      set (cisstNetlib_ARCHITECTURE "i686")
     endif (CMAKE_CL_64)
   else (WIN32)
     # we assume Linux
     if(${CMAKE_SIZEOF_VOID_P} EQUAL 8)
-      set (CISSTNETLIB_ARCHITECTURE "x86_64")
+      set (cisstNetlib_ARCHITECTURE "x86_64")
     else ()
-      set (CISSTNETLIB_ARCHITECTURE "i686")
+      set (cisstNetlib_ARCHITECTURE "i686")
     endif ()
     # end of Linux case
   endif (WIN32)
 endif (APPLE)
 
 # --- now, download proper lapack
-if ("${CISSTNETLIB_LANGUAGE}" STREQUAL "C")
-  set (CISSTNETLIB_C_BASED 1)
-  set (CISSTNETLIB_FORTRAN_BASED 0)
-  set (CISSTNETLIB_LAPACK_URL "http://netlib.org/clapack/clapack-3.2.1-CMAKE.tgz")
-  set (CISSTNETLIB_LAPACK_URL_MD5 4fd18eb33f3ff8c5d65a7d43913d661b)
-else ("${CISSTNETLIB_LANGUAGE}" STREQUAL "C")
-  set (CISSTNETLIB_C_BASED 0)
-  set (CISSTNETLIB_FORTRAN_BASED 1)
-  set (CISSTNETLIB_LAPACK_URL "https://github.com/Reference-LAPACK/lapack/archive/refs/tags/v3.10.1.tar.gz")
-  set (CISSTNETLIB_LAPACK_URL_MD5 722407217a080a0012ae3d6913fb8008)
-  # older MD5 if needed
-  # 3.5.0 set (CISSTNETLIB_LAPACK_URL_MD5 b1d3e3e425b2e44a06760ff173104bdf)
-  # 3.4.2 set (CISSTNETLIB_LAPACK_URL_MD5 61bf1a8a4469d4bdb7604f5897179478)
-endif ("${CISSTNETLIB_LANGUAGE}" STREQUAL "C")
+if ("${cisstNetlib_LANGUAGE}" STREQUAL "C")
+  set (cisstNetlib_C_BASED 1)
+  set (cisstNetlib_FORTRAN_BASED 0)
+else ("${cisstNetlib_LANGUAGE}" STREQUAL "C")
+  set (cisstNetlib_C_BASED 0)
+  set (cisstNetlib_FORTRAN_BASED 1)
+endif ("${cisstNetlib_LANGUAGE}" STREQUAL "C")
 
-set (CISSTNETLIB_VERSION_MAJOR 3)
-set (CISSTNETLIB_VERSION_MINOR 0)
-set (CISSTNETLIB_VERSION_REVISION 0)
-set (CISSTNETLIB_VERSION ${CISSTNETLIB_VERSION_MAJOR}.${CISSTNETLIB_VERSION_MINOR}.${CISSTNETLIB_VERSION_REVISION})
+set (cisstNetlib_VERSION ${cisstNetlib_VERSION_MAJOR}.${cisstNetlib_VERSION_MINOR}.${cisstNetlib_VERSION_PATCH})
 
 if (NOT WIN32)
   set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
@@ -109,15 +101,16 @@ set (CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bin")
 # --- get and compile lapack
 include (ExternalProject)
 
-set (CISSTNETLIB_EXTERNAL_NAME cisstNetlib_${CISSTNETLIB_LANGUAGE})
-set (CISSTNETLIB_EXTERNAL_PREFIX cisstNetlibLapack)
+set (cisstNetlib_EXTERNAL_NAME cisstNetlib_${cisstNetlib_LANGUAGE})
+set (cisstNetlib_EXTERNAL_PREFIX cisstNetlibLapack)
 
-ExternalProject_Add (
-  ${CISSTNETLIB_EXTERNAL_NAME}
-  PREFIX ${CISSTNETLIB_EXTERNAL_PREFIX}
-  URL ${CISSTNETLIB_LAPACK_URL}
-  URL_MD5 ${CISSTNETLIB_LAPACK_URL_MD5}
-  CMAKE_CACHE_ARGS
+if (cisstNetlib_C_BASED)
+  ExternalProject_Add (
+    ${cisstNetlib_EXTERNAL_NAME}
+    PREFIX ${cisstNetlib_EXTERNAL_PREFIX}
+    GIT_REPOSITORY "https://github.com/jhu-cisst-external/clapack"
+    GIT_TAG "main"
+    CMAKE_CACHE_ARGS
     -DBUILD_SINGLE:BOOL=OFF
     -DBUILD_COMPLEX:BOOL=OFF
     -DBUILD_COMPLEX16:BOOL=OFF
@@ -129,27 +122,53 @@ ExternalProject_Add (
     -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}
     -DCMAKE_CXX_COMPILER:STRING=${CMAKE_CXX_COMPILER}
     -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS}
-  INSTALL_COMMAND ""
-  # TEST_BEFORE_INSTALL 1
-)
+    INSTALL_COMMAND ""
+    )
+
+else (cisstNetlib_C_BASED)
+  set (cisstNetlib_LAPACK_URL "https://github.com/Reference-LAPACK/lapack/archive/refs/tags/v3.10.1.tar.gz")
+  set (cisstNetlib_LAPACK_URL_MD5 722407217a080a0012ae3d6913fb8008)
+  # older MD5 if needed
+  # 3.5.0 set (cisstNetlib_LAPACK_URL_MD5 b1d3e3e425b2e44a06760ff173104bdf)
+  # 3.4.2 set (cisstNetlib_LAPACK_URL_MD5 61bf1a8a4469d4bdb7604f5897179478)
+  ExternalProject_Add (
+    ${cisstNetlib_EXTERNAL_NAME}
+    PREFIX ${cisstNetlib_EXTERNAL_PREFIX}
+    URL ${cisstNetlib_LAPACK_URL}
+    URL_MD5 ${cisstNetlib_LAPACK_URL_MD5}
+    CMAKE_CACHE_ARGS
+    -DBUILD_SINGLE:BOOL=OFF
+    -DBUILD_COMPLEX:BOOL=OFF
+    -DBUILD_COMPLEX16:BOOL=OFF
+    -DCMAKE_OSX_ARCHITECTURES:STRING=${CMAKE_OSX_ARCHITECTURES}
+    -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+    -DCMAKE_Fortran_COMPILER:STRING=${CMAKE_Fortran_COMPILER}
+    -DCMAKE_Fortran_FLAGS:STRING=${CMAKE_Fortran_FLAGS}
+    -DCMAKE_C_COMPILER:STRING=${CMAKE_C_COMPILER}
+    -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}
+    -DCMAKE_CXX_COMPILER:STRING=${CMAKE_CXX_COMPILER}
+    -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS}
+    INSTALL_COMMAND ""
+    )
+endif (cisstNetlib_C_BASED)
 
 
 # --- figure out where the external project has compiled its libraries
-set (CISSTNETLIB_LAPACK_ROOT "${CMAKE_CURRENT_BINARY_DIR}/${CISSTNETLIB_EXTERNAL_PREFIX}")
-set (CISSTNETLIB_LAPACK_BUILD_DIR "${CISSTNETLIB_LAPACK_ROOT}/src/${CISSTNETLIB_EXTERNAL_NAME}-build")
+set (cisstNetlib_LAPACK_ROOT "${CMAKE_CURRENT_BINARY_DIR}/${cisstNetlib_EXTERNAL_PREFIX}")
+set (cisstNetlib_LAPACK_BUILD_DIR "${cisstNetlib_LAPACK_ROOT}/src/${cisstNetlib_EXTERNAL_NAME}-build")
 
 # --- include directories for f2c code not part of clapack
-if (CISSTNETLIB_C_BASED)
-  include_directories ("${CISSTNETLIB_LAPACK_ROOT}/src/${CISSTNETLIB_EXTERNAL_NAME}/F2CLIBS/libf2c"
-                       "${CISSTNETLIB_LAPACK_ROOT}/src/${CISSTNETLIB_EXTERNAL_NAME}/INCLUDE")
-endif (CISSTNETLIB_C_BASED)
+if (cisstNetlib_C_BASED)
+  include_directories ("${cisstNetlib_LAPACK_ROOT}/src/${cisstNetlib_EXTERNAL_NAME}/F2CLIBS/libf2c"
+                       "${cisstNetlib_LAPACK_ROOT}/src/${cisstNetlib_EXTERNAL_NAME}/INCLUDE")
+endif (cisstNetlib_C_BASED)
 
 # --- compile extra numerical routines
 add_subdirectory (hanson-haskell)
-add_dependencies (cisstNetlib_hanson_haskell cisstNetlib_${CISSTNETLIB_LANGUAGE})
+add_dependencies (cisstNetlib_hanson_haskell cisstNetlib_${cisstNetlib_LANGUAGE})
 
 add_subdirectory (lawson-hanson)
-add_dependencies (cisstNetlib_lawson_hanson cisstNetlib_${CISSTNETLIB_LANGUAGE})
+add_dependencies (cisstNetlib_lawson_hanson cisstNetlib_${cisstNetlib_LANGUAGE})
 
 # --- compile c wrappers to hide all f2c references and typedefs
 include_directories (${CMAKE_CURRENT_SOURCE_DIR}/include
@@ -157,13 +176,13 @@ include_directories (${CMAKE_CURRENT_SOURCE_DIR}/include
                      ${CMAKE_CURRENT_SOURCE_DIR})
 
 # should really read, look into f2c.h to figure which one it is
-if (CISSTNETLIB_C_BASED)
-  set (CISSTNETLIB_INTEGER "long int")
-  set (CISSTNETLIB_DOUBLE "double")
-else (CISSTNETLIB_C_BASED)
-  set (CISSTNETLIB_INTEGER "int")
-  set (CISSTNETLIB_DOUBLE "double")
-endif (CISSTNETLIB_C_BASED)
+if (cisstNetlib_C_BASED)
+  set (cisstNetlib_INTEGER "long int")
+  set (cisstNetlib_DOUBLE "double")
+else (cisstNetlib_C_BASED)
+  set (cisstNetlib_INTEGER "int")
+  set (cisstNetlib_DOUBLE "double")
+endif (cisstNetlib_C_BASED)
 
 configure_file (cisstNetlib.h.in "${CMAKE_CURRENT_BINARY_DIR}/include/cisstNetlib.h")
 configure_file (cisstNetlib-types.h.in "${CMAKE_CURRENT_BINARY_DIR}/include/cisstNetlib/cisstNetlib-types.h")
@@ -176,7 +195,7 @@ install (FILES "${CMAKE_CURRENT_BINARY_DIR}/include/cisstNetlib/cisstNetlib-type
          DESTINATION "include/cisstNetlib/")
 
 add_subdirectory (cisstNetlib-wrappers)
-add_dependencies (cisstNetlib cisstNetlib_${CISSTNETLIB_LANGUAGE})
+add_dependencies (cisstNetlib cisstNetlib_${cisstNetlib_LANGUAGE})
 
 # --- do we need the "Release"/"Debug" suffix to find libraries
 if (WIN32)
@@ -185,39 +204,39 @@ else (WIN32)
   set (LIB_SUBDIR "/")
 endif (WIN32)
 
-if (CISSTNETLIB_C_BASED)
+if (cisstNetlib_C_BASED)
   # --- C - find and install all libraries with new names, also copy in current binary so we can use local build as an install tree
-  set (CISSTNETLIB_lapack_lib "${CISSTNETLIB_LAPACK_BUILD_DIR}/SRC${LIB_SUBDIR}${CMAKE_STATIC_LIBRARY_PREFIX}lapack${CMAKE_STATIC_LIBRARY_SUFFIX}")
+  set (cisstNetlib_lapack_lib "${cisstNetlib_LAPACK_BUILD_DIR}/SRC${LIB_SUBDIR}${CMAKE_STATIC_LIBRARY_PREFIX}lapack${CMAKE_STATIC_LIBRARY_SUFFIX}")
   set (newFileName "${CMAKE_STATIC_LIBRARY_PREFIX}cisstNetlib_lapack${CMAKE_STATIC_LIBRARY_SUFFIX}")
-  install (FILES "${CISSTNETLIB_lapack_lib}"
+  install (FILES "${cisstNetlib_lapack_lib}"
            DESTINATION "lib"
            RENAME "${newFileName}")
 
-  set (CISSTNETLIB_blas_lib "${CISSTNETLIB_LAPACK_BUILD_DIR}/BLAS/SRC${LIB_SUBDIR}${CMAKE_STATIC_LIBRARY_PREFIX}blas${CMAKE_STATIC_LIBRARY_SUFFIX}")
+  set (cisstNetlib_blas_lib "${cisstNetlib_LAPACK_BUILD_DIR}/BLAS/SRC${LIB_SUBDIR}${CMAKE_STATIC_LIBRARY_PREFIX}blas${CMAKE_STATIC_LIBRARY_SUFFIX}")
   set (newFileName "${CMAKE_STATIC_LIBRARY_PREFIX}cisstNetlib_blas${CMAKE_STATIC_LIBRARY_SUFFIX}")
-  install (FILES "${CISSTNETLIB_blas_lib}"
+  install (FILES "${cisstNetlib_blas_lib}"
            DESTINATION "lib"
            RENAME "${newFileName}")
 
   # - note: for we don't know what reason the f2c has a static prefic "lib" in F2CLIBS/libf2c/CMakeLists.txt
-  set (CISSTNETLIB_f2c_lib "${CISSTNETLIB_LAPACK_BUILD_DIR}/F2CLIBS/libf2c${LIB_SUBDIR}libf2c${CMAKE_STATIC_LIBRARY_SUFFIX}")
+  set (cisstNetlib_f2c_lib "${cisstNetlib_LAPACK_BUILD_DIR}/F2CLIBS/libf2c${LIB_SUBDIR}libf2c${CMAKE_STATIC_LIBRARY_SUFFIX}")
   set (newFileName "${CMAKE_STATIC_LIBRARY_PREFIX}cisstNetlib_f2c${CMAKE_STATIC_LIBRARY_SUFFIX}")
-  install (FILES "${CISSTNETLIB_f2c_lib}"
+  install (FILES "${cisstNetlib_f2c_lib}"
            DESTINATION "lib"
            RENAME "${newFileName}")
 
-else (CISSTNETLIB_C_BASED)
+else (cisstNetlib_C_BASED)
 
   # --- Fortran - find and install all libraries with new names
-  set (CISSTNETLIB_lapack_lib "${CISSTNETLIB_LAPACK_BUILD_DIR}/lib${LIB_SUBDIR}${CMAKE_STATIC_LIBRARY_PREFIX}lapack${CMAKE_STATIC_LIBRARY_SUFFIX}")
+  set (cisstNetlib_lapack_lib "${cisstNetlib_LAPACK_BUILD_DIR}/lib${LIB_SUBDIR}${CMAKE_STATIC_LIBRARY_PREFIX}lapack${CMAKE_STATIC_LIBRARY_SUFFIX}")
   set (newFileName "${CMAKE_STATIC_LIBRARY_PREFIX}cisstNetlib_lapack${CMAKE_STATIC_LIBRARY_SUFFIX}")
-  install (FILES "${CISSTNETLIB_lapack_lib}"
+  install (FILES "${cisstNetlib_lapack_lib}"
            DESTINATION "lib"
            RENAME "${newFileName}")
 
-  set (CISSTNETLIB_blas_lib "${CISSTNETLIB_LAPACK_BUILD_DIR}/lib${LIB_SUBDIR}${CMAKE_STATIC_LIBRARY_PREFIX}blas${CMAKE_STATIC_LIBRARY_SUFFIX}")
+  set (cisstNetlib_blas_lib "${cisstNetlib_LAPACK_BUILD_DIR}/lib${LIB_SUBDIR}${CMAKE_STATIC_LIBRARY_PREFIX}blas${CMAKE_STATIC_LIBRARY_SUFFIX}")
   set (newFileName "${CMAKE_STATIC_LIBRARY_PREFIX}cisstNetlib_blas${CMAKE_STATIC_LIBRARY_SUFFIX}")
-  install (FILES "${CISSTNETLIB_blas_lib}"
+  install (FILES "${cisstNetlib_blas_lib}"
            DESTINATION "lib"
            RENAME "${newFileName}")
 
@@ -251,10 +270,10 @@ else (CISSTNETLIB_C_BASED)
            DESTINATION "lib"
            RENAME "${CMAKE_STATIC_LIBRARY_PREFIX}cisstNetlib_quadmath${CMAKE_STATIC_LIBRARY_SUFFIX}")
 
-endif (CISSTNETLIB_C_BASED)
+endif (cisstNetlib_C_BASED)
 
 # -- configure CMake config file for cisstnetlib
-if (CISSTNETLIB_C_BASED)
+if (cisstNetlib_C_BASED)
   set (cisstNetlib_LIBRARIES_SHORT_NAMES
        cisstNetlib
        cisstNetlib_hanson_haskell
@@ -262,7 +281,7 @@ if (CISSTNETLIB_C_BASED)
        cisstNetlib_lapack
        cisstNetlib_blas
        cisstNetlib_f2c)
-else (CISSTNETLIB_C_BASED)
+else (cisstNetlib_C_BASED)
   set (cisstNetlib_LIBRARIES_SHORT_NAMES
        cisstNetlib
        cisstNetlib_hanson_haskell
@@ -272,7 +291,7 @@ else (CISSTNETLIB_C_BASED)
        cisstNetlib_gfortran
        cisstNetlib_quadmath
        cisstNetlib_gcc)
-endif (CISSTNETLIB_C_BASED)
+endif (cisstNetlib_C_BASED)
 
 configure_file (CisstNetlibConfig.cmake.in
                 "${CMAKE_CURRENT_BINARY_DIR}/CisstNetlibConfig.cmake"
@@ -282,9 +301,9 @@ install (FILES "${CMAKE_CURRENT_BINARY_DIR}/CisstNetlibConfig.cmake"
 
 # --- prepare installer, tgz on unix systems
 set (CPACK_GENERATOR "TGZ;ZIP;DEB")
-set (CPACK_PACKAGE_DESCRIPTION_SUMMARY "JHU CISST binary distribution of netlib.org routines (${CISSTNETLIB_LANGUAGE} version)")
-set (CPACK_SYSTEM_NAME "${CMAKE_SYSTEM_NAME}-${CISSTNETLIB_ARCHITECTURE}")
-set (CPACK_PACKAGE_NAME "cisstNetlib-${CISSTNETLIB_LANGUAGE}")
+set (CPACK_PACKAGE_DESCRIPTION_SUMMARY "JHU CISST binary distribution of netlib.org routines (${cisstNetlib_LANGUAGE} version)")
+set (CPACK_SYSTEM_NAME "${CMAKE_SYSTEM_NAME}-${cisstNetlib_ARCHITECTURE}")
+set (CPACK_PACKAGE_NAME "cisstNetlib-${cisstNetlib_LANGUAGE}")
 set (CPACK_PACKAGE_VENDOR "JHU")
 set (CPACK_PACKAGE_VERSION "3.1.0")
 set (CPACK_PACKAGE_VERSION_MAJOR "3")

--- a/CisstNetlibConfig.cmake.in
+++ b/CisstNetlibConfig.cmake.in
@@ -2,7 +2,7 @@
 # Author(s):  Anton Deguet
 # Created on: 2012-12-09
 #
-# (C) Copyright 2012-2022 Johns Hopkins University (JHU), All Rights Reserved.
+# (C) Copyright 2012-2023 Johns Hopkins University (JHU), All Rights Reserved.
 #
 # Provide cisstNetlibConfig.cmake, defines includes and libraries
 #
@@ -10,8 +10,6 @@
 # cisstNetlib_INCLUDE_DIR, where to find headers
 # cisstNetlib_LIBRARIES, the libraries to link against to use isi_api.
 # cisstNetlib_FOUND, If false, do not try to use isi_api.
-#
-# Capitalized version of variables is provided for backward compatibility (CISSTNETLIB_xyz)
 
 # This file is assumed to be used when installed with the libraries
 # and will only work when maintained relative to the rest of the tree

--- a/cisstNetlib-types.h.in
+++ b/cisstNetlib-types.h.in
@@ -2,13 +2,10 @@
 /* ex: set filetype=cpp softtabstop=4 shiftwidth=4 tabstop=4 cindent expandtab: */
 
 /*
-  $Id$
-
   Author(s):  Anton Deguet
   Created on: 2012-09-25
 
-  (C) Copyright 2012-2013 Johns Hopkins University (JHU), All Rights
-  Reserved.
+  (C) Copyright 2012-2023 Johns Hopkins University (JHU), All Rights Reserved.
 
 --- begin cisst license - do not edit ---
 
@@ -25,8 +22,8 @@ http://www.cisst.org/cisst/license.txt.
 #ifndef _cisstNetlib_types_h
 #define _cisstNetlib_types_h
 
-typedef ${CISSTNETLIB_INTEGER} CISSTNETLIB_INTEGER;
-typedef ${CISSTNETLIB_DOUBLE} CISSTNETLIB_DOUBLE;
+typedef ${cisstNetlib_INTEGER} CISSTNETLIB_INTEGER;
+typedef ${cisstNetlib_DOUBLE} CISSTNETLIB_DOUBLE;
 
 #endif // _cisstNetlib_types_h
 

--- a/cisstNetlib.h.in
+++ b/cisstNetlib.h.in
@@ -2,13 +2,10 @@
 /* ex: set filetype=cpp softtabstop=4 shiftwidth=4 tabstop=4 cindent expandtab: */
 
 /*
-  $Id$
-
   Author(s):  Anton Deguet
   Created on: 2012-09-25
 
-  (C) Copyright 2012-2013 Johns Hopkins University (JHU), All Rights
-  Reserved.
+  (C) Copyright 2012-2023 Johns Hopkins University (JHU), All Rights Reserved.
 
 --- begin cisst license - do not edit ---
 
@@ -25,11 +22,12 @@ http://www.cisst.org/cisst/license.txt.
 #ifndef _cisstNetlib_h
 #define _cisstNetlib_h
 
-#define CISSTNETLIB_VERSION @CISSTNETLIB_VERSION@
-#define CISSTNETLIB_VERSION_MAJOR @CISSTNETLIB_VERSION_MAJOR@
-#define CISSTNETLIB_VERSION_MINOR @CISSTNETLIB_VERSION_MINOR@
-#define CISSTNETLIB_C_BASED @CISSTNETLIB_C_BASED@
-#define CISSTNETLIB_FORTRAN_BASED @CISSTNETLIB_FORTRAN_BASED@
+#define cisstNetlib_VERSION @cisstNetlib_VERSION@
+#define cisstNetlib_VERSION_MAJOR @cisstNetlib_VERSION_MAJOR@
+#define cisstNetlib_VERSION_MINOR @cisstNetlib_VERSION_MINOR@
+#define cisstNetlib_VERSION_PATCH @cisstNetlib_VERSION_PATCH@
+#define cisstNetlib_C_BASED @cisstNetlib_C_BASED@
+#define cisstNetlib_FORTRAN_BASED @cisstNetlib_FORTRAN_BASED@
 
 extern "C" {
 #include <cisstNetlib/cisstNetlib-types.h>

--- a/hanson-haskell/CMakeLists.txt
+++ b/hanson-haskell/CMakeLists.txt
@@ -2,13 +2,13 @@
 # Author(s):  Anton Deguet
 # Created on: 2012-12-09
 #
-# (C) Copyright 2012-2022 Johns Hopkins University (JHU), All Rights Reserved.
+# (C) Copyright 2012-2023 Johns Hopkins University (JHU), All Rights Reserved.
 #
 
-project (cisstNetlib_hanson_haskell VERSION ${cisstNetlib_VERSION})
+project (cisstNetlib_hanson_haskell LANGUAGES ${cisstNetlib_LANGUAGES} VERSION ${cisstNetlib_VERSION})
 
-if (CISSTNETLIB_C_BASED)
+if (cisstNetlib_C_BASED)
   add_subdirectory (fortran-f2c)
-else (CISSTNETLIB_C_BASED)
+else (cisstNetlib_C_BASED)
   add_subdirectory (fortran)
-endif (CISSTNETLIB_C_BASED)
+endif (cisstNetlib_C_BASED)

--- a/hanson-haskell/fortran-f2c/CMakeLists.txt
+++ b/hanson-haskell/fortran-f2c/CMakeLists.txt
@@ -1,12 +1,11 @@
 #
-# $Id$
-#
 # Author(s):  Anton Deguet
 # Created on: 2012-12-09
 #
-# (C) Copyright 2012-2013 Johns Hopkins University (JHU), All Rights
-# Reserved.
+# (C) Copyright 2012-2023 Johns Hopkins University (JHU), All Rights Reserved.
 #
+
+project (cisstNetlib_hanson_haskell_C LANGUAGES ${cisstNetlib_LANGUAGES} VERSION ${cisstNetlib_VERSION})
 
 set (cisstNetlib_hanson_haskell_SOURCES
      drotm.c

--- a/hanson-haskell/fortran/CMakeLists.txt
+++ b/hanson-haskell/fortran/CMakeLists.txt
@@ -2,10 +2,10 @@
 # Author(s):  Anton Deguet
 # Created on: 2012-12-09
 #
-# (C) Copyright 2012-2022 Johns Hopkins University (JHU), All Rights Reserved.
+# (C) Copyright 2012-2023 Johns Hopkins University (JHU), All Rights Reserved.
 #
 
-project (cisstNetlib_hanson_haskell_Fortran VERSION ${cisstNetlib_VERSION})
+project (cisstNetlib_hanson_haskell_Fortran LANGUAGES ${cisstNetlib_LANGUAGES} VERSION ${cisstNetlib_VERSION})
 
 set (cisstNetlib_hanson_haskell_SOURCES
      drotm.f

--- a/lawson-hanson/CMakeLists.txt
+++ b/lawson-hanson/CMakeLists.txt
@@ -2,13 +2,13 @@
 # Author(s):  Anton Deguet
 # Created on: 2012-12-09
 #
-# (C) Copyright 2012-2022 Johns Hopkins University (JHU), All Rights Reserved.
+# (C) Copyright 2012-2023 Johns Hopkins University (JHU), All Rights Reserved.
 #
 
-project (cisstNetlib_lawson_hanson VERSION ${cisstNetlib_VERSION})
+project (cisstNetlib_lawson_hanson LANGUAGES ${cisstNetlib_LANGUAGES} VERSION ${cisstNetlib_VERSION})
 
-if (CISSTNETLIB_C_BASED)
+if (cisstNetlib_C_BASED)
   add_subdirectory (fortran-f2c)
-else (CISSTNETLIB_C_BASED)
+else (cisstNetlib_C_BASED)
   add_subdirectory (fortran)
-endif (CISSTNETLIB_C_BASED)
+endif (cisstNetlib_C_BASED)

--- a/lawson-hanson/fortran-f2c/CMakeLists.txt
+++ b/lawson-hanson/fortran-f2c/CMakeLists.txt
@@ -1,12 +1,11 @@
 #
-# $Id$
-#
 # Author(s):  Anton Deguet
 # Created on: 2012-12-09
 #
-# (C) Copyright 2012-2013 Johns Hopkins University (JHU), All Rights
-# Reserved.
+# (C) Copyright 2012-2023 Johns Hopkins University (JHU), All Rights Reserved.
 #
+
+project (cisstNetlib_lawson_hanson_C LANGUAGES ${cisstNetlib_LANGUAGES} VERSION ${cisstNetlib_VERSION})
 
 set (cisstNetlib_lawson_hanson_SOURCES
      diff.c

--- a/lawson-hanson/fortran/CMakeLists.txt
+++ b/lawson-hanson/fortran/CMakeLists.txt
@@ -2,10 +2,10 @@
 # Author(s):  Anton Deguet
 # Created on: 2012-12-09
 #
-# (C) Copyright 2012-2022 Johns Hopkins University (JHU), All Rights Reserved.
+# (C) Copyright 2012-2023 Johns Hopkins University (JHU), All Rights Reserved.
 #
 
-project (cisstNetlib_lawson_hanson_Fortran VERSION ${cisstNetlib_VERSION})
+project (cisstNetlib_lawson_hanson_Fortran LANGUAGES ${cisstNetlib_LANGUAGES} VERSION ${cisstNetlib_VERSION})
 
 set (cisstNetlib_lawson_hanson_SOURCES
      diff.f


### PR DESCRIPTION
…tps://github.com/jhu-cisst-external/clapack so we can patch clapack for new OS/compilers